### PR TITLE
Fix Null Pointer Exception in vm.rs with_env

### DIFF
--- a/jni-glue/src/vm.rs
+++ b/jni-glue/src/vm.rs
@@ -1,37 +1,43 @@
 use super::*;
 
 /// FFI: Use **&VM** instead of *const JavaVM.  This represents a global, process-wide Java exection environment.
-/// 
+///
 /// On Android, there is only one VM per-process, although on desktop it's possible (if rare) to have multiple VMs
 /// within the same process.  While this library does not yet support having multiple VMs active simultaniously, please
 /// don't hesitate to [file an issue](https://github.com/MaulingMonkey/jni-bindgen/issues/new) if this is an important
 /// use case for you.
 ///
 /// This is a "safe" alternative to jni_sys::JavaVM raw pointers, with the following caveats:
-/// 
+///
 /// 1)  A null vm will result in **undefined behavior**.  Java should not be invoking your native functions with a null
 ///     *mut JavaVM, however, so I don't believe this is a problem in practice unless you've bindgened the C header
 ///     definitions elsewhere, calling them (requiring `unsafe`), and passing null pointers (generally UB for JNI
 ///     functions anyways, so can be seen as a caller soundness issue.)
-/// 
+///
 /// 2)  Allowing the underlying JavaVM to be modified is **undefined behavior**.  I don't believe the JNI libraries
 ///     modify the JavaVM, so as long as you're not accepting a *mut JavaVM elsewhere, using unsafe to dereference it,
 ///     and mucking with the methods on it yourself, I believe this "should" be fine.
 #[repr(transparent)]
-pub struct VM(JavaVM);
+pub struct VM(*const JavaVM);
 impl VM {
-    pub fn as_java_vm(&self) -> *const JavaVM { &self.0 }
-    pub unsafe fn from_jni_local(vm: &JavaVM) -> &VM { &*(vm as *const JavaVM as *const VM) }
+    pub fn as_java_vm(&self) -> *mut JavaVM {
+        self as *const VM as *mut JavaVM
+    }
+    pub unsafe fn from_jni_local(vm: &JavaVM) -> &VM {
+        &*(vm as *const JavaVM as *const VM)
+    }
 
     pub fn with_env<F, R>(&self, callback: F) -> R
     where
         F: FnOnce(&Env) -> R,
     {
-        let mut java_vm = self.0;
+        let java_vm = self.as_java_vm();
         let mut env = null_mut();
-        match unsafe { (*java_vm).GetEnv.unwrap()(&mut java_vm, &mut env, JNI_VERSION_1_2) } {
+        match unsafe { (**java_vm).GetEnv.unwrap()(java_vm, &mut env, JNI_VERSION_1_2) } {
             JNI_OK => callback(unsafe { Env::from_jni_void_ref(&env) }),
-            JNI_EDETACHED => match unsafe { (*java_vm).AttachCurrentThread.unwrap()(&mut java_vm, &mut env, null_mut()) } {
+            JNI_EDETACHED => match unsafe {
+                (**java_vm).AttachCurrentThread.unwrap()(java_vm, &mut env, null_mut())
+            } {
                 JNI_OK => callback(unsafe { Env::from_jni_void_ref(&env) }),
                 unexpected => panic!("AttachCurrentThread returned unknown error: {}", unexpected),
             },


### PR DESCRIPTION
I ran into this issue when dropping a Global. When trying to get the env in `with_env` it would end up dereferencing one step too many and end up with a null pointer exception in the VM's JNI code.

I pictured it like this:

Given
`*const JavaVM = *const *const jni_sys::JNIInvokeInterface_;`. A valid `*const JavaVM` would be a pointer `A` which points to a pointer `B` which points to the `JNIInvokeInterface_`. At some point we went one step to far and treated pointer `B` as `*const *const jni_sys::JNIInvokeInterface_;`. So when we dereferenced B twice to get `JNIInvokeInterface_` we actually end up somewhere random (and leads us into a null ptr exception).

I think the problem is that it would dereference it once when it was accessed via self.0 because of `repr(transparent)`. (it may be something else though, but this stuff is tricky).

I changed VM to hold a `VM(*const JavaVM);` since that is what you are given in JNI_OnLoad and that made more sense to me. Then I used the `as_java_vm` helper to make sure I get a valid `*mut JavaVM` keeping in mind the `rear(transparent`.