### PR TITLE
String conversion improvements

### DIFF
--- a/jni-android-sys/src/extras/strings.rs
+++ b/jni-android-sys/src/extras/strings.rs
@@ -10,6 +10,16 @@ use std::char::DecodeUtf16Error;
 
 
 impl java::lang::String {
+    fn from_string_chars<'env>(string_chars: &StringChars<'env>) -> Local<'env, Self> {
+        let (env, string) = unsafe { string_chars.as_env_jstring() };
+        unsafe { Local::from_env_object(env.as_jni_env() as *const _, string) }
+    }
+
+    /// Create new local string from an Env + AsRef<str>
+    pub fn from_env_str<'env, S: AsRef<str>>(env: &'env Env, string: S) -> Local<'env, Self> {
+        Self::from_string_chars(&StringChars::from_env_str(env, string))
+    }
+
     fn string_chars(&self) -> StringChars {
         unsafe {
             let env = Env::from_ptr(self.0.env);

--- a/jni-android-sys/src/extras/strings.rs
+++ b/jni-android-sys/src/extras/strings.rs
@@ -10,14 +10,16 @@ use std::char::DecodeUtf16Error;
 
 
 impl java::lang::String {
-    fn from_string_chars<'env>(string_chars: &StringChars<'env>) -> Local<'env, Self> {
-        let (env, string) = unsafe { string_chars.as_env_jstring() };
-        unsafe { Local::from_env_object(env.as_jni_env() as *const _, string) }
-    }
-
     /// Create new local string from an Env + AsRef<str>
     pub fn from_env_str<'env, S: AsRef<str>>(env: &'env Env, string: S) -> Local<'env, Self> {
-        Self::from_string_chars(&StringChars::from_env_str(env, string))
+        let chars = string.as_ref().encode_utf16().collect::<Vec<_>>();
+
+        let string = unsafe { env.new_string(
+            chars.as_ptr() as *const jchar,
+            chars.len() as jni_sys::jsize,
+        ) };
+
+        unsafe { Local::from_env_object(env.as_jni_env() as *const _, string) }
     }
 
     fn string_chars(&self) -> StringChars {

--- a/jni-glue/src/env.rs
+++ b/jni-glue/src/env.rs
@@ -66,6 +66,11 @@ impl Env {
 
     // String methods
 
+    pub unsafe fn new_string(&self, chars: *const jchar, len: jsize) -> jstring {
+        let env = &self.0 as *const JNIEnv as *mut JNIEnv;
+        (**env).NewString.unwrap()(env, chars as *const _, len)
+    }
+
     pub unsafe fn get_string_length(&self, string: jstring) -> jsize {
         let env = &self.0 as *const JNIEnv as *mut JNIEnv;
         (**env).GetStringLength.unwrap()(env, string)

--- a/jni-glue/src/string_chars.rs
+++ b/jni-glue/src/string_chars.rs
@@ -1,5 +1,5 @@
 use super::{*, jchar};
-use std::{char, slice, iter, cell::Cell, ptr::null, mem::transmute};
+use std::{char, slice, iter, mem::transmute};
 
 
 
@@ -8,7 +8,7 @@ use std::{char, slice, iter, cell::Cell, ptr::null, mem::transmute};
 pub struct StringChars<'env> {
     env:    &'env Env,
     string: jstring,
-    chars:  Cell<*const jchar>,
+    chars:  *const jchar,
     length: jsize, // in characters
 }
 
@@ -17,8 +17,9 @@ impl<'env> StringChars<'env> {
     pub unsafe fn from_env_jstring(env: &'env Env, string: jstring) -> Self {
         debug_assert!(!string.is_null());
 
-        let chars = Cell::new(null());
+        let chars  = env.get_string_chars(string);
         let length = env.get_string_length(string);
+
         Self {
             env,
             string,
@@ -27,30 +28,11 @@ impl<'env> StringChars<'env> {
         }
     }
 
-    /// Construct a StringChars from an Env + AsRef<str>
-    pub fn from_env_str<S: AsRef<str>>(env: &'env Env, string: S) -> Self {
-        let chars = string.as_ref().encode_utf16().collect::<Vec<_>>();
-        let string = unsafe { env.new_string(
-            chars.as_ptr() as *const jchar,
-            chars.len() as jsize,
-        ) };
-        unsafe { Self::from_env_jstring(env, string) }
-    }
-
-    /// Get an Env + jstring from StringChars
-    pub unsafe fn as_env_jstring(&self) -> (&'env Env, jstring) {
-        (self.env, self.string)
-    }
-
     /// Get an array of [jchar]s.  Generally UTF16, but not guaranteed to be valid UTF16.
     /// 
     /// [jchar]:                    struct.jchar.html
     pub fn chars(&self) -> &[jchar] {
-        if self.chars.get().is_null() {
-            // Get string chars
-            self.chars.set(unsafe { self.env.get_string_chars(self.string) });
-        }
-        unsafe { slice::from_raw_parts(self.chars.get(), self.length as usize) }
+        unsafe { slice::from_raw_parts(self.chars, self.length as usize) }
     }
 
     /// Get an array of [u16]s.  Generally UTF16, but not guaranteed to be valid UTF16.
@@ -87,9 +69,6 @@ impl<'env> StringChars<'env> {
 
 impl<'env> Drop for StringChars<'env> {
     fn drop(&mut self) {
-        let chars = self.chars.get();
-        if !chars.is_null() {
-            unsafe { self.env.release_string_chars(self.string, chars) };
-        }
+        unsafe { self.env.release_string_chars(self.string, self.chars) };
     }
 }


### PR DESCRIPTION
- Implemented java string creation from rust `AsRef<str>`.
- Getting character data from java string at the moment when it actually needed, and releasing it only if it got before.

Fix for #58 